### PR TITLE
Add context error to box error output

### DIFF
--- a/lib/boxr/errors.rb
+++ b/lib/boxr/errors.rb
@@ -19,8 +19,10 @@ module Boxr
             @box_status = body_json["status"]
             @code = body_json["code"]
             @help_uri = body_json["help_uri"]
-            @box_message = body_json["message"]
             @request_id = body_json["request_id"]
+
+            error_details = body_json['context_info']['errors'].map { |error| error['message'] }.join(', ')
+            @box_message = "#{body_json['message']}, #{error_details}"
           end
         rescue
         end

--- a/spec/boxr_spec.rb
+++ b/spec/boxr_spec.rb
@@ -590,4 +590,10 @@ describe Boxr::Client do
     deleted_webhook  = BOX_CLIENT.delete_webhook(updated_webhook)
     expect(deleted_webhook).to be_empty
   end
+
+  it 'shows detailed errors' do
+    expect do
+      BOX_CLIENT.create_folder(nil, @test_folder)
+    end.to raise_error(Boxr::BoxrError, "400: Bad Request, 'name' is required")
+  end
 end


### PR DESCRIPTION
Box.com provides a subset of error data called `context_info`. These are the more descriptive errors that explain why a request failed.