### PR TITLE
Remove Base64 decoding of JWT private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,6 @@ Or install it yourself as:
 
 ## Usage
 
-**Important**
-You must encode your private key and set that as your JWT_PRIVATE_KEY environment variable. To encode, open irb or a Rails console on do the following:
-```
-require 'base64'
-Base64.strict_encode64(private_key)
-```
-
 Super-fast instructions:
 
 1. go to http://developers.box.com
@@ -113,7 +106,7 @@ You can get all these keys from your application's JSON configuration file in th
 # The enterprise ID is pre-populated by the JSON configuration,
 # so you don't need to specify it here
 enterprise_token = Boxr::get_enterprise_token.access_token
-service_account_client = Boxr::Client.new(enterprise_token) 
+service_account_client = Boxr::Client.new(enterprise_token)
 
 # Get an app user client
 app_user        = service_account_client.create_user('User Name', 'some@email.com', is_platform_access_only: true))

--- a/lib/boxr/auth.rb
+++ b/lib/boxr/auth.rb
@@ -29,7 +29,7 @@ module Boxr
     auth_post(uri, body)
   end
 
-  def self.get_enterprise_token(private_key: Base64.strict_decode64(ENV['JWT_PRIVATE_KEY']), private_key_password: ENV['JWT_PRIVATE_KEY_PASSWORD'],
+  def self.get_enterprise_token(private_key: ENV['JWT_PRIVATE_KEY'], private_key_password: ENV['JWT_PRIVATE_KEY_PASSWORD'],
                                 public_key_id: ENV['JWT_PUBLIC_KEY_ID'], enterprise_id: ENV['BOX_ENTERPRISE_ID'],
                                 client_id: ENV['BOX_CLIENT_ID'], client_secret: ENV['BOX_CLIENT_SECRET'])
     unlocked_private_key = unlock_key(private_key, private_key_password)
@@ -37,7 +37,7 @@ module Boxr
     get_token(grant_type: JWT_GRANT_TYPE, assertion: assertion, client_id: client_id, client_secret: client_secret)
   end
 
-  def self.get_user_token(user_id, private_key: Base64.strict_decode64(ENV['JWT_PRIVATE_KEY']), private_key_password: ENV['JWT_PRIVATE_KEY_PASSWORD'],
+  def self.get_user_token(user_id, private_key: ENV['JWT_PRIVATE_KEY'], private_key_password: ENV['JWT_PRIVATE_KEY_PASSWORD'],
                           public_key_id: ENV['JWT_PUBLIC_KEY_ID'], client_id: ENV['BOX_CLIENT_ID'], client_secret: ENV['BOX_CLIENT_SECRET'])
     unlocked_private_key = unlock_key(private_key, private_key_password)
     assertion = jwt_assertion(unlocked_private_key, client_id, user_id, 'user', public_key_id)

--- a/lib/boxr/client.rb
+++ b/lib/boxr/client.rb
@@ -65,7 +65,7 @@ module Boxr
                    client_id: ENV['BOX_CLIENT_ID'],
                    client_secret: ENV['BOX_CLIENT_SECRET'],
                    enterprise_id: ENV['BOX_ENTERPRISE_ID'],
-                   jwt_private_key: Base64.strict_decode64(ENV['JWT_PRIVATE_KEY']),
+                   jwt_private_key: ENV['JWT_PRIVATE_KEY'],
                    jwt_private_key_password: ENV['JWT_PRIVATE_KEY_PASSWORD'],
                    jwt_public_key_id: ENV['JWT_PUBLIC_KEY_ID'],
                    identifier: nil,


### PR DESCRIPTION
Our existing support of a Base64 encoded JWT_PRIVATE_KEY assumed that it was _always_ present. A nil key would cause an `undefined method unpack1 for nil:NilClass` exception during authorization. I'm removing support for now.